### PR TITLE
Extend Postman collection based on Typesense v28

### DIFF
--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -273,6 +273,277 @@
 					"description": "Vector Search API [document](https://typesense.org/docs/28.0/api/vector-search.html)"
 				},
 				{
+					"name": "JOINs",
+					"item": [
+						{
+							"name": "Create authors collection",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"authors\",\n  \"fields\": [\n    {\"name\": \"first_name\", \"type\": \"string\"},\n    {\"name\": \"last_name\", \"type\": \"string\"}\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create books collection with reference",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"books\",\n  \"fields\": [\n    {\"name\": \"title\", \"type\": \"string\"},\n    {\"name\": \"author_id\", \"type\": \"string\", \"reference\": \"authors.id\"}\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Index an author",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"first_name\": \"Enid\",\n  \"last_name\": \"Blyton\"\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections",
+										"authors",
+										"documents"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Index a book",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"Famous Five\",\n  \"author_id\": \"0\"\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections",
+										"books",
+										"documents"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search books with joined author (One-to-One)",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"searches\": [\n    {\n      \"collection\": \"books\",\n      \"q\": \"famous\",\n      \"query_by\": \"title\",\n      \"include_fields\": \"$authors(first_name,last_name)\"\n    }\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"multi_search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create customers collection",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"customers\",\n  \"fields\": [\n    {\"name\": \"forename\", \"type\": \"string\"},\n    {\"name\": \"surname\", \"type\": \"string\"},\n    {\"name\": \"email\", \"type\": \"string\"}\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create orders collection with reference",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"orders\",\n  \"fields\": [\n    {\"name\": \"total_price\", \"type\": \"float\"},\n    {\"name\": \"initial_date\", \"type\": \"int64\"},\n    {\"name\": \"accepted_date\", \"type\": \"int64\", \"optional\": true},\n    {\"name\": \"completed_date\", \"type\": \"int64\", \"optional\": true},\n    {\"name\": \"customer_id\", \"type\": \"string\", \"reference\": \"customers.id\"}\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search customers with joined orders (One-to-Many)",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"searches\": [\n    {\n      \"collection\": \"customers\",\n      \"q\": \"*\",\n      \"filter_by\": \"$orders(total_price:<100)\",\n      \"include_fields\": \"$orders(total_price)\"\n    }\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"multi_search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search authors with books (Nested Array)",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"searches\": [\n    {\n      \"collection\": \"authors\",\n      \"q\": \"*\",\n      \"filter_by\": \"$books(id:*)\",\n      \"include_fields\": \"$books(*, strategy: nest_array)\"\n    }\n  ]\n}"
+								},
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"multi_search"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "JOINs API [document](https://typesense.org/docs/28.0/api/joins.html)"
+				},
+				{
 					"name": "Geosearch",
 					"item": [
 						{

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -1253,6 +1253,125 @@
 			"description": "Synonyms API [document](https://typesense.org/docs/28.0/api/synonyms.html#synonyms)"
 		},
 		{
+			"name": "Stemming",
+			"item": [
+				{
+					"name": "Import stemming dictionary",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"word\": \"people\", \"root\": \"person\"}\n{\"word\": \"children\", \"root\": \"child\"}\n{\"word\": \"geese\", \"root\": \"goose\"}"
+						},
+						"url": {
+							"raw": "{{url}}/stemming/dictionaries/import?id={{stemming_dictionary_name}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stemming",
+								"dictionaries",
+								"import"
+							],
+							"query": [
+								{
+									"key": "id",
+									"value": "{{stemming_dictionary_name}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List all stemming dictionaries",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stemming",
+								"dictionaries"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Retrieve a stemming dictionary",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stemming",
+								"dictionaries",
+								"{{stemming_dictionary_name}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create collection with stemming",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"companies_with_stemming\",\n  \"fields\": [\n    {\"name\": \"company_name\", \"type\": \"string\"},\n    {\"name\": \"description\", \"type\": \"string\", \"stem\": true},\n    {\"name\": \"specialties\", \"type\": \"string\", \"stem_dictionary\": \"{{stemming_dictionary_name}}\"}\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{url}}/collections",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"collections"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Stemming API [document](https://typesense.org/docs/28.0/api/stemming.html#stemming)"
+		},
+		{
 			"name": "Stopwords",
 			"item": [
 				{

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -947,6 +947,150 @@
 			"description": "Document API [document](https://typesense.org/docs/28.0/api/documents.html#documents)"
 		},
 		{
+			"name": "Analytics & Query Suggestions",
+			"item": [
+				{
+					"name": "Create analytics collection",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{analytics_collection_name}}\",\n  \"fields\": [\n    {\"name\": \"q\", \"type\": \"string\" },\n    {\"name\": \"count\", \"type\": \"int32\" }\n  ]\n}"
+						},
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"collections"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create analytics rule",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"{{analytics_rule_name}}\",\n  \"type\": \"popular_queries\",\n  \"params\": {\n    \"source\": {\n      \"collections\": [\"{{collection_name}}\"]\n    },\n    \"destination\": {\n      \"collection\": \"{{analytics_collection_name}}\"\n    },\n    \"limit\": 1000\n  }\n}"
+						},
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"analytics",
+								"rules"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List all analytics rules",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"analytics",
+								"rules"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete an analytics rule",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"analytics",
+								"rules",
+								"{{analytics_rule_name}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Search with query suggestions",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							},
+							{
+								"key": "X-TYPESENSE-USER-ID",
+								"value": "user123",
+								"description": "Optional user identifier for analytics"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"searches\": [\n    {\n      \"collection\": \"{{analytics_collection_name}}\",\n      \"q\": \"shoe\",\n      \"query_by\": \"q\"\n    },\n    {\n      \"collection\": \"{{collection_name}}\",\n      \"q\": \"shoe\",\n      \"query_by\": \"company_name\"\n    }\n  ]\n}"
+						},
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"multi_search"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Analytics & Query Suggestions API [document](https://typesense.org/docs/28.0/api/analytics-query-suggestions.html)"
+		},
+		{
 			"name": "Api Keys",
 			"item": [
 				{

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -353,6 +353,146 @@
 					"description": "Geosearch API [document](https://typesense.org/docs/28.0/api/geosearch.html#geosearch)"
 				},
 				{
+					"name": "Image Search",
+					"item": [
+						{
+							"name": "Create collection with image field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"image_collection_name\", jsonData.name);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"images\",\n  \"fields\": [\n    {\n      \"name\": \"name\",\n      \"type\": \"string\"\n    },\n    {\n      \"name\": \"image\",\n      \"type\": \"image\",\n      \"store\": false\n    },\n    {\n      \"name\": \"embedding\",\n      \"type\": \"float[]\",\n      \"embed\": {\n        \"from\": [\n          \"image\"\n        ],\n        \"model_config\": {\n          \"model_name\": \"ts/clip-vit-b-p32\"\n        }\n      }\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{url}}/collections",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Index document with image",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"an image with a dog\",\n    \"image\": \"<base64 encoded string of the image>\"\n}"
+								},
+								"url": {
+									"raw": "{{url}}/collections/{{image_collection_name}}/documents",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections",
+										"{{image_collection_name}}",
+										"documents"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search for images with description",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"searches\": [\n    {\n      \"collection\": \"{{image_collection_name}}\",\n      \"q\": \"animals\",\n      \"query_by\": \"embedding\"\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{url}}/multi_search",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"multi_search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search for similar images",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"searches\": [\n    {\n      \"collection\": \"{{image_collection_name}}\",\n      \"q\": \"*\",\n      \"vector_query\": \"embedding:([], id:123)\"\n    }\n  ]\n}"
+								},
+								"url": {
+									"raw": "{{url}}/multi_search",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"multi_search"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Image Search API [document](https://typesense.org/docs/28.0/api/image-search.html)"
+				},
+				{
 					"name": "Presets",
 					"item": [
 						{

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -155,6 +155,124 @@
 			"name": "Documents",
 			"item": [
 				{
+					"name": "Semantic Search",
+					"item": [
+						{
+							"name": "Collection create",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"embedding_collection_name\", jsonData.name);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n \"name\": \"products\",\n \"fields\": [\n {\n \"name\": \"product_name\",\n \"type\": \"string\"\n },\n {\n \"name\": \"embedding\",\n \"type\": \"float[]\",\n \"embed\": {\n \"from\": [\n \"product_name\"\n ],\n \"model_config\": {\n \"model_name\": \"ts/all-MiniLM-L12-v2\"\n }\n }\n }\n]}"
+								},
+								"url": {
+									"raw": "{{url}}/collections",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Index  a doc",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"product_name\": \"French Press\"\n}"
+								},
+								"url": {
+									"raw": "{{url}}/collections/{{embedding_collection_name}}/documents",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections",
+										"{{embedding_collection_name}}",
+										"documents"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-TYPESENSE-API-KEY",
+										"value": "{{TYPESENSE_API_KEY}}"
+									}
+								],
+								"url": {
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"collections",
+										"{{embedding_collection_name}}",
+										"documents",
+										"search"
+									],
+									"query": [
+										{
+											"key": "q",
+											"value": "Coffee Maker"
+										},
+										{
+											"key": "query_by",
+											"value": "product_name"
+										},
+										{
+											"key": "exclude_fields",
+											"value": "embedding"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Vector Search API [document](https://typesense.org/docs/28.0/api/vector-search.html)"
+				},
+				{
 					"name": "Geosearch",
 					"item": [
 						{

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -1253,6 +1253,146 @@
 			"description": "Synonyms API [document](https://typesense.org/docs/28.0/api/synonyms.html#synonyms)"
 		},
 		{
+			"name": "Stopwords",
+			"item": [
+				{
+					"name": "Create or update a stopwords set",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"stopwords\": [\"Germany\", \"France\", \"Italy\", \"United States\"],\n    \"locale\": \"en\"\n}"
+						},
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stopwords",
+								"{{stopword_set_name}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List all stopwords sets",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stopwords"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Retrieve a stopwords set",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stopwords",
+								"{{stopword_set_name}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete a stopwords set",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/stopwords/{{stopword_set_name}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"stopwords",
+								"{{stopword_set_name}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Search with stopwords",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"collections",
+								"{{collection_name}}",
+								"documents",
+								"search"
+							],
+							"query": [
+								{
+									"key": "q",
+									"value": "united states"
+								},
+								{
+									"key": "query_by",
+									"value": "country"
+								},
+								{
+									"key": "stopwords",
+									"value": "{{stopword_set_name}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Stopwords API [document](https://typesense.org/docs/28.0/api/stopwords.html#stopwords)"
+		},
+		{
 			"name": "Cluster Operations",
 			"item": [
 				{

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -120,7 +120,7 @@
 					"response": []
 				}
 			],
-			"description": "Collection API [document](https://typesense.org/docs/0.24.1/api/collections.html#collections)."
+			"description": "Collection API [document](https://typesense.org/docs/28.0/api/collections.html#collections)."
 		},
 		{
 			"name": "Documents",
@@ -203,7 +203,7 @@
 							"response": []
 						}
 					],
-					"description": "Geosearch API [document](https://typesense.org/docs/0.24.1/api/geosearch.html#geosearch)"
+					"description": "Geosearch API [document](https://typesense.org/docs/28.0/api/geosearch.html#geosearch)"
 				},
 				{
 					"name": "Presets",
@@ -268,7 +268,7 @@
 							"response": []
 						}
 					],
-					"description": "Preset API [document](https://typesense.org/docs/0.24.1/api/search.html#presets)"
+					"description": "Preset API [document](https://typesense.org/docs/28.0/api/search.html#presets)"
 				},
 				{
 					"name": "Index a document",
@@ -657,7 +657,7 @@
 					"response": []
 				}
 			],
-			"description": "Document API [document](https://typesense.org/docs/0.24.1/api/documents.html#documents)"
+			"description": "Document API [document](https://typesense.org/docs/28.0/api/documents.html#documents)"
 		},
 		{
 			"name": "Api Keys",
@@ -773,7 +773,7 @@
 					"response": []
 				}
 			],
-			"description": "Api key [Document](https://typesense.org/docs/0.24.1/api/api-keys.html#api-keys)"
+			"description": "Api key [Document](https://typesense.org/docs/28.0/api/api-keys.html#api-keys)"
 		},
 		{
 			"name": "Curation",
@@ -886,7 +886,7 @@
 					"response": []
 				}
 			],
-			"description": "Curation API [document](https://typesense.org/docs/0.24.1/api/curation.html#curation)"
+			"description": "Curation API [document](https://typesense.org/docs/28.0/api/curation.html#curation)"
 		},
 		{
 			"name": "Collection Alias",
@@ -991,7 +991,7 @@
 					"response": []
 				}
 			],
-			"description": "Collection ALIAS [document](https://typesense.org/docs/0.24.1/api/collection-alias.html#collection-alias)"
+			"description": "Collection ALIAS [document](https://typesense.org/docs/28.0/api/collection-alias.html#collection-alias)"
 		},
 		{
 			"name": "Synonyms",
@@ -1103,7 +1103,7 @@
 					"response": []
 				}
 			],
-			"description": "Synonyms API [document](https://typesense.org/docs/0.24.1/api/synonyms.html#synonyms)"
+			"description": "Synonyms API [document](https://typesense.org/docs/28.0/api/synonyms.html#synonyms)"
 		},
 		{
 			"name": "Cluster Operations",
@@ -1261,7 +1261,7 @@
 					"response": []
 				}
 			],
-			"description": "Operations [document](https://typesense.org/docs/0.24.1/api/cluster-operations.html#cluster-operations)"
+			"description": "Operations [document](https://typesense.org/docs/28.0/api/cluster-operations.html#cluster-operations)"
 		}
 	]
 }

--- a/typesense.postman_collection.json
+++ b/typesense.postman_collection.json
@@ -118,6 +118,35 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Truncate a collection",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-TYPESENSE-API-KEY",
+								"value": "{{TYPESENSE_API_KEY}}"
+							}
+						],
+						"url": {
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"collections",
+								"{{collection_name}}",
+								"documents"
+							],
+							"query": [
+								{
+									"key": "truncate",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"description": "Collection API [document](https://typesense.org/docs/28.0/api/collections.html#collections)."

--- a/typesense.postman_environment.json
+++ b/typesense.postman_environment.json
@@ -33,6 +33,11 @@
 			"enabled": true
 		},
 		{
+			"key": "image_collection_name",
+			"value": "images",
+			"enabled": true
+		},
+		{
 			"key": "stemming_dictionary_name",
 			"value": "stemming_dictionary1",
 			"enabled": true

--- a/typesense.postman_environment.json
+++ b/typesense.postman_environment.json
@@ -33,6 +33,11 @@
 			"enabled": true
 		},
 		{
+			"key": "stemming_dictionary_name",
+			"value": "stemming_dictionary1",
+			"enabled": true
+		},
+		{
 			"key": "apikey_id",
 			"value": "",
 			"enabled": true

--- a/typesense.postman_environment.json
+++ b/typesense.postman_environment.json
@@ -9,7 +9,7 @@
 		},
 		{
 			"key": "TYPESENSE_API_KEY",
-			"value": "1234",
+			"value": "xyz",
 			"enabled": true
 		},
 		{

--- a/typesense.postman_environment.json
+++ b/typesense.postman_environment.json
@@ -28,6 +28,11 @@
 			"enabled": true
 		},
 		{
+			"key": "stopword_set_name",
+			"value": "stopword_set1",
+			"enabled": true
+		},
+		{
 			"key": "apikey_id",
 			"value": "",
 			"enabled": true

--- a/typesense.postman_environment.json
+++ b/typesense.postman_environment.json
@@ -43,6 +43,16 @@
 			"enabled": true
 		},
 		{
+			"key": "analytics_collection_name",
+			"value": "product_queries",
+			"enabled": true
+		},
+		{
+			"key": "analytics_rule_name",
+			"value": "product_queries_aggregation",
+			"enabled": true
+		},
+		{
 			"key": "apikey_id",
 			"value": "",
 			"enabled": true


### PR DESCRIPTION
### TLDR
Extended Postman collection with JOINs, Analytics, Image Search, Stemming, and Stopwords APIs.

## Change Summary
### What is this?
This PR enhances the Typesense Postman collection by adding several new API sections that cover advanced search functionalities. It adds examples for JOINs, Analytics, Query Suggestions, Image Search, Stemming, and Stopwords, making it easier for developers to test and understand Typesense's full capabilities.

### Changes

#### Added Features:

1. **JOINs API Section**:
   - Added folder with endpoints for creating related collections with references
   - Included examples for one-to-one relationships (books-authors)
   - Included examples for one-to-many relationships (customers-orders)
   - Demonstrated nested array results strategy for efficient data retrieval

2. **Analytics & Query Suggestions API Section**:
   - Added endpoints for creating analytics collections and rules
   - Added endpoints for listing and deleting analytics rules
   - Included example for searching with query suggestions
   - Updated environment variables with analytics collection and rule names

3. **Image Search API Section**:
   - Added endpoints for collection creation with image field
   - Included examples for indexing images with embedded vectors
   - Added search endpoints for text-to-image and image-to-image similarity search
   - Updated environment variables with image collection name

4. **Stemming API Section**:
   - Added endpoints for importing, listing, and retrieving stemming dictionaries
   - Included example for creating collections with stemming configuration
   - Added environment variable for stemming dictionary name

5. **Stopwords API Section**:
   - Added endpoints for creating, updating, and retrieving stopwords sets
   - Included example for searching with stopwords
   - Added environment variable for stopword set name

6. **Semantic Search Section**:
   - Added folder for vector embedding-based semantic search
   - Included examples for creating collections with embedding fields
   - Added endpoint for semantic search queries

7. **Other Improvements**:
   - Added endpoint for truncating collections
   - Fixed default API key in environment to use `xyz` instead of `1234`
   - Added documentation links for all new API sections

Each new section includes examples with proper request configurations, making it easy for users to understand and experiment with Typesense's powerful search capabilities.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
